### PR TITLE
Fix SIGSEGV on macOS

### DIFF
--- a/src/src/server.cpp
+++ b/src/src/server.cpp
@@ -116,7 +116,7 @@ void ServerPrivate::onTimeout()
 void ServerPrivate::onReadyRead()
 {
     // Read the packet from the socket
-    QUdpSocket *socket = dynamic_cast<QUdpSocket*>(sender());
+    QUdpSocket *socket = qobject_cast<QUdpSocket*>(sender());
     QByteArray packet;
     packet.resize(socket->pendingDatagramSize());
     QHostAddress address;


### PR DESCRIPTION
When building on macOS with gcc-7, qmdnsengine crashes with the following error
`error: libqmdnsengine.0.dylib :: Class 'ServerPrivate' has a base class 'QObject' which does not have a complete definition.`

Using `qobject_cast` instead of `dynamic_cast` fixes the issue.