### PR TITLE
Correct QMDNSENGINE_EXPORT when BUILD_SHARED_LIBS is undefined

### DIFF
--- a/src/qmdnsengine_export.h.in
+++ b/src/qmdnsengine_export.h.in
@@ -36,7 +36,7 @@
 #    define QMDNSENGINE_EXPORT Q_DECL_IMPORT
 #  endif
 #else
-#  define QHTTPENGINE_EXPORT
+#  define QMDNSENGINE_EXPORT
 #endif
 
 #endif // QMDNSENGINE_EXPORT_H


### PR DESCRIPTION
The `!BUILD_SHARED_LIBS` case in the qmdnsengine_export.h.in configuration file is broken and results in a fire hose of compilation errors due to compilation proceeding with `QMDNSENGINE_EXPORT` undefined.