### PR TITLE
Fix handling of service names with dots

### DIFF
--- a/src/src/browser.cpp
+++ b/src/src/browser.cpp
@@ -63,7 +63,7 @@ BrowserPrivate::BrowserPrivate(Browser *browser, AbstractServer *server, const Q
 bool BrowserPrivate::updateService(const QByteArray &fqName)
 {
     // Split the FQDN into service name and type
-    int index = fqName.indexOf('.');
+    int index = fqName.indexOf('_') - 1;
     QByteArray serviceName = fqName.left(index);
     QByteArray serviceType = fqName.mid(index + 1);
 

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -38,7 +38,7 @@
 
 Q_DECLARE_METATYPE(QMdnsEngine::Service)
 
-const QByteArray Name = "Test";
+const QByteArray Name = "Test.DotTest";
 const QByteArray Type = "_test._tcp.local.";
 const QByteArray Fqdn = Name + "." + Type;
 const QByteArray Target = "Test.local.";


### PR DESCRIPTION
QMdnsEngine currently assumes service names will not contain dots. This causes it to mishandle mDNS responses for NVIDIA GameStream which contain several dots in the service name.

The following is an example of such a response:
`_nvstream._tcp.local: type PTR, class IN, 3.14.0.161-WIN10-GS.765ebd34-e2e9-4502-8fdd-5e8ed485b667._nvstream._tcp.local`

The current parsing logic results in `3` being considered the service name, rather than `3.14.0.161-WIN10-GS.765ebd34-e2e9-4502-8fdd-5e8ed485b667`. Other mDNS implementations I've tried (jmDNS and NSNetServiceBrowser) return the expected service name.

I updated the Browser unit test to exercise this fix.