### PR TITLE
Fix the Resolver example in the docs to use the correct name

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -76,7 +76,7 @@ QObject::connect(&browser, &QMdnsEngine::Browser::serviceAdded,
 To resolve the service, use a [Resolver](@ref QMdnsEngine::Resolver):
 
 @code
-QMdnsEngine::Resolver resolver(&server, service.name(), &cache);
+QMdnsEngine::Resolver resolver(&server, service.hostname(), &cache);
 QObject::connect(&resolver, &QMdnsEngine::Resolver::resolved,
     [](const QHostAddress &address) {
         qDebug() << "resolved to" << address;


### PR DESCRIPTION
The example for `Resolver` in the docs say to use `Service::name()`, but the correct way to resolve a host advertising a service is to use `Service::hostname()` as the browser sample does.