### PR TITLE
Fix new/delete mismatch caught by ASAN

### DIFF
--- a/src/src/bitmap.cpp
+++ b/src/src/bitmap.cpp
@@ -42,7 +42,7 @@ BitmapPrivate::~BitmapPrivate()
 void BitmapPrivate::free()
 {
     if (data) {
-        delete data;
+        delete[] data;
     }
 }
 


### PR DESCRIPTION
BitmapPrivate::data is allocated using the `new []` operator, therefore it must be freed using `delete []` not `delete`.

ASAN throws the following error:
```
==29120==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x6020003b1a10
    #0 0x7ffff72ef708 in operator delete(void*) (/usr/lib64/libasan.so.5+0xf2708)
    #1 0x52dd84 in QMdnsEngine::BitmapPrivate::free() /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/bitmap.cpp:45
    #2 0x52dd31 in QMdnsEngine::BitmapPrivate::~BitmapPrivate() /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/bitmap.cpp:39
    #3 0x52dd4d in QMdnsEngine::BitmapPrivate::~BitmapPrivate() /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/bitmap.cpp:40
    #4 0x52e019 in QMdnsEngine::Bitmap::~Bitmap() /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/bitmap.cpp:91
    #5 0x52e878 in QMdnsEngine::parseRecord(QByteArray const&, unsigned short&, QMdnsEngine::Record&) /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/dns.cpp:178
    #6 0x52f840 in QMdnsEngine::fromPacket(QByteArray const&, QMdnsEngine::Message&) /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/dns.cpp:330
    #7 0x52b8b0 in QMdnsEngine::ServerPrivate::onReadyRead() /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/server.cpp:128
    #8 0x52c19d in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (QMdnsEngine::ServerPrivate::*)()>::call(void (QMdnsEngine::ServerPrivate::*)(), QMdnsEngine::ServerPrivate*, void**) /usr/include/qt5/QtCore/qobjectdefs_impl.h:134
    #9 0x52c12f in void QtPrivate::FunctionPointer<void (QMdnsEngine::ServerPrivate::*)()>::call<QtPrivate::List<>, void>(void (QMdnsEngine::ServerPrivate::*)(), QMdnsEngine::ServerPrivate*, void**) /usr/include/qt5/QtCore/qobjectdefs_impl.h:167
    #10 0x52c07e in QtPrivate::QSlotObject<void (QMdnsEngine::ServerPrivate::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) /usr/include/qt5/QtCore/qobjectdefs_impl.h:396
    #11 0x7ffff3ee01c2 in QMetaObject::activate(QObject*, int, int, void**) (/usr/lib64/libQt5Core.so.5+0x27a1c2)
    #12 0x7ffff4236102  (/usr/lib64/libQt5Network.so.5+0xf0102)
    #13 0x7ffff4236193  (/usr/lib64/libQt5Network.so.5+0xf0193)
    #14 0x7ffff4248cf8  (/usr/lib64/libQt5Network.so.5+0x102cf8)
    #15 0x7ffff3eb7e34  (/usr/lib64/libQt5Core.so.5+0x251e34)
    #16 0x7ffff3eb7ec5 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (/usr/lib64/libQt5Core.so.5+0x251ec5)
    #17 0x7ffff3f08f4b  (/usr/lib64/libQt5Core.so.5+0x2a2f4b)
    #18 0x7ffff28ed06c in g_main_context_dispatch (/usr/lib64/libglib-2.0.so.0+0x4f06c)
    #19 0x7ffff28ed437  (/usr/lib64/libglib-2.0.so.0+0x4f437)
    #20 0x7ffff28ed4cf in g_main_context_iteration (/usr/lib64/libglib-2.0.so.0+0x4f4cf)
    #21 0x7ffff3f08592 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib64/libQt5Core.so.5+0x2a2592)
    #22 0x7fffda96b854  (/usr/lib64/libQt5XcbQpa.so.5+0xde854)
    #23 0x7ffff3eb6e0a in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib64/libQt5Core.so.5+0x250e0a)
    #24 0x7ffff3ebeed5 in QCoreApplication::exec() (/usr/lib64/libQt5Core.so.5+0x258ed5)
    #25 0x41e900 in main /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/app/main.cpp:469
    #26 0x7ffff36d5412 in __libc_start_main (/usr/lib64/libc.so.6+0x24412)
    #27 0x41aa3d in _start (/home/cgutman/moonlight-src/qt-workspace/build-moonlight-qt-Desktop-Debug/app/moonlight+0x41aa3d)

0x6020003b1a10 is located 0 bytes inside of 5-byte region [0x6020003b1a10,0x6020003b1a15)
allocated by thread T0 here:
    #0 0x7ffff72eea10 in operator new[](unsigned long) (/usr/lib64/libasan.so.5+0xf1a10)
    #1 0x52dda8 in QMdnsEngine::BitmapPrivate::fromData(unsigned char, unsigned char const*) /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/bitmap.cpp:51
    #2 0x52e0ae in QMdnsEngine::Bitmap::setData(unsigned char, unsigned char const*) /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/bitmap.cpp:107
    #3 0x52e822 in QMdnsEngine::parseRecord(QByteArray const&, unsigned short&, QMdnsEngine::Record&) /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/dns.cpp:179
    #4 0x52f840 in QMdnsEngine::fromPacket(QByteArray const&, QMdnsEngine::Message&) /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/dns.cpp:330
    #5 0x52b8b0 in QMdnsEngine::ServerPrivate::onReadyRead() /home/cgutman/moonlight-src/qt-workspace/moonlight-qt/qmdnsengine/qmdnsengine/src/src/server.cpp:128
    #6 0x52c19d in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (QMdnsEngine::ServerPrivate::*)()>::call(void (QMdnsEngine::ServerPrivate::*)(), QMdnsEngine::ServerPrivate*, void**) /usr/include/qt5/QtCore/qobjectdefs_impl.h:134
    #7 0x52c12f in void QtPrivate::FunctionPointer<void (QMdnsEngine::ServerPrivate::*)()>::call<QtPrivate::List<>, void>(void (QMdnsEngine::ServerPrivate::*)(), QMdnsEngine::ServerPrivate*, void**) /usr/include/qt5/QtCore/qobjectdefs_impl.h:167
    #8 0x52c07e in QtPrivate::QSlotObject<void (QMdnsEngine::ServerPrivate::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) /usr/include/qt5/QtCore/qobjectdefs_impl.h:396
    #9 0x7ffff3ee01c2 in QMetaObject::activate(QObject*, int, int, void**) (/usr/lib64/libQt5Core.so.5+0x27a1c2)
    #10 0x7ffff4236102  (/usr/lib64/libQt5Network.so.5+0xf0102)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch (/usr/lib64/libasan.so.5+0xf2708) in operator delete(void*)
==29120==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==29120==ABORTING
```