### PR TITLE
Fix handling multiple records with flush cache set

### DIFF
--- a/src/include/qmdnsengine/cache.h
+++ b/src/include/qmdnsengine/cache.h
@@ -78,8 +78,8 @@ public:
      * @param record add this record to the cache
      *
      * The TTL for the record will be added to the current time to calculate
-     * when the record expires. Existing records of the same name and type
-     * will be replaced, resetting their expiration.
+     * when the record expires. Call invalidateRecord() before addRecord()
+     * to ensure any superseded records are removed.
      */
     void addRecord(const Record &record);
 
@@ -105,6 +105,15 @@ public:
      */
     bool lookupRecords(const QByteArray &name, quint16 type, QList<Record> &records) const;
 
+    /**
+     * @brief Invalidates the specified record in the cache
+     * @param record invalidate this record in the cache
+     *
+     * This must be called for all records in a message prior to adding
+     * any records to the cache to ensure the case of multiple records with
+     * the same type and 'flush cache' set is handled properly.
+     */
+    void invalidateRecord(const Record &record);
 Q_SIGNALS:
 
     /**

--- a/src/src/browser.cpp
+++ b/src/src/browser.cpp
@@ -117,6 +117,13 @@ void BrowserPrivate::onMessageReceived(const Message &message)
         return;
     }
 
+    // Invalidate each record in the cache first. This ensures
+    // that we properly handle the case where we have multiple
+    // records of the same type with 'flush cache' set.
+    foreach (Record record, message.records()) {
+        cache->invalidateRecord(record);
+    }
+
     // Use a set to track all services that are updated in the message to
     // prevent unnecessary queries for SRV and TXT records
     QSet<QByteArray> updateNames;

--- a/src/src/resolver.cpp
+++ b/src/src/resolver.cpp
@@ -88,6 +88,14 @@ void ResolverPrivate::onMessageReceived(const Message &message)
     if (!message.isResponse()) {
         return;
     }
+
+    // Invalidate each record in the cache first. This ensures
+    // that we properly handle the case where we have multiple
+    // records of the same type with 'flush cache' set.
+    foreach (Record record, message.records()) {
+        cache->invalidateRecord(record);
+    }
+
     foreach (Record record, message.records()) {
         if (record.name() == name && (record.type() == A || record.type() == AAAA)) {
             cache->addRecord(record);

--- a/tests/TestCache.cpp
+++ b/tests/TestCache.cpp
@@ -94,6 +94,7 @@ void TestCache::testRemoval()
 
     // Purge the record from the cache by setting its TTL to 0
     record.setTtl(0);
+    cache.invalidateRecord(record);
     cache.addRecord(record);
 
     // Verify that the record is gone
@@ -115,6 +116,7 @@ void TestCache::testCacheFlush()
     // Insert a new record with the cache clear bit set
     QMdnsEngine::Record record = createRecord();
     record.setFlushCache(true);
+    cache.invalidateRecord(record);
     cache.addRecord(record);
 
     // Confirm that only a single record exists


### PR DESCRIPTION
Currently, invalidation of superseded records is handled in `Cache::addRecord()` as each record is added to the cache. However, this breaks when there are multiple records of the same type in a single message with 'flush cache' set. In that case, the records that were just added in the same message get immediately superseded and only the final record of that type persists in the cache.

To fix this, use 2 passes to update the cache when we receive a message. First, invalidate any records that will be superseded by those contained within the message, then add all records from the message to the cache.