### PR TITLE
Send multicast packets on all multicast-capable interfaces

### DIFF
--- a/src/src/server.cpp
+++ b/src/src/server.cpp
@@ -153,6 +153,14 @@ void Server::sendMessageToAll(const Message &message)
 {
     QByteArray packet;
     toPacket(message, packet);
-    d->ipv4Socket.writeDatagram(packet, MdnsIpv4Address, MdnsPort);
-    d->ipv6Socket.writeDatagram(packet, MdnsIpv6Address, MdnsPort);
+
+    foreach (QNetworkInterface interface, QNetworkInterface::allInterfaces()) {
+        if (interface.flags() & QNetworkInterface::CanMulticast) {
+            d->ipv4Socket.setMulticastInterface(interface);
+            d->ipv4Socket.writeDatagram(packet, MdnsIpv4Address, MdnsPort);
+
+            d->ipv6Socket.setMulticastInterface(interface);
+            d->ipv6Socket.writeDatagram(packet, MdnsIpv6Address, MdnsPort);
+        }
+    }
 }


### PR DESCRIPTION
On multi-homed hosts, the interface that will be used for outgoing multicast traffic is implementation-defined. As a result, the mDNS queries don't always go out on the interfaces where the discoverable hosts are.

We want to ensure that `Server::sendMessageToAll()` sends queries to all multicast-capable interfaces, so we should use `QUdpSocket::setMulticastInterface()` to do that. 