### PR TITLE
Only include PTR records that correspond to the query target

### DIFF
--- a/src/src/browser.cpp
+++ b/src/src/browser.cpp
@@ -214,9 +214,9 @@ void BrowserPrivate::onQueryTimeout()
 
     // TODO: including too many records could cause problems
 
-    // Include all currently valid PTR records
+    // Include PTR records for the target that are already known
     QList<Record> records;
-    if (cache->lookupRecords(QByteArray(), PTR, records)) {
+    if (cache->lookupRecords(query.name(), PTR, records)) {
         foreach (Record record, records) {
             message.addRecord(record);
         }


### PR DESCRIPTION
When issuing PTR queries, QMdnsEngine includes cached PTR records for Known-Answer Suppression pursuant to RFC 6762 Section 7.1. However, we include _all_ PTR records, not just the ones that are answers for the name in the query being sent. Since we snoop on mDNS responses on the network and add entries to our cache, this amounts to all non-expired PTR records that have been requested by anyone since we've been listening. For networks with many mDNS clients, this can amount to a huge number of records.

In my case, I saw over 70 PTR answer records for all sorts of random services attached to a PTR query issued by QMdnsEngine. The resulting query was over 1KB large.