### PR TITLE
Don't remove service when PTR record expires

### DIFF
--- a/src/src/browser.cpp
+++ b/src/src/browser.cpp
@@ -181,14 +181,11 @@ void BrowserPrivate::onShouldQuery(const Record &record)
 
 void BrowserPrivate::onRecordExpired(const Record &record)
 {
-    // If the PTR or SRV record has expired for a service, then it must be
+    // If the SRV record has expired for a service, then it must be
     // removed - TXT records on the other hand, cause an update
 
     QByteArray serviceName;
     switch (record.type()) {
-    case PTR:
-        serviceName = record.target();
-        break;
     case SRV:
         serviceName = record.name();
         break;


### PR DESCRIPTION
Emitting the serviceRemoved signal when the PTR record expires results in the following unexpected behavior: when a PTR, TXT and SRV record exist for a service and they expire in that order it will trigger the serviceRemoved, serviceAdded and serviceRemoved signal.

The serviceAdded / serviceUpdate signals are only emitted for services that have an SRV record in the cache, so I think it makes sense to not trigger serviceRemoved while a valid SRV record is present in the cache.