### PR TITLE
Only cache relevant records to avoid additional overhead on network

### DIFF
--- a/src/src/browser.cpp
+++ b/src/src/browser.cpp
@@ -107,6 +107,7 @@ bool BrowserPrivate::updateService(const QByteArray &fqName)
     }
 
     services.insert(fqName, service);
+    hostnames.insert(service.hostname());
 
     return false;
 }
@@ -117,28 +118,36 @@ void BrowserPrivate::onMessageReceived(const Message &message)
         return;
     }
 
+    const bool any = type == MdnsBrowseType;
+
     // Use a set to track all services that are updated in the message to
     // prevent unnecessary queries for SRV and TXT records
     QSet<QByteArray> updateNames;
     const auto records = message.records();
     for (const Record &record : records) {
-        cache->addRecord(record);
-        bool any = type == MdnsBrowseType;
+        bool cacheRecord = false;
+
         switch (record.type()) {
         case PTR:
             if (any && record.name() == MdnsBrowseType) {
                 ptrTargets.insert(record.target());
                 serviceTimer.start();
+                cacheRecord = true;
             } else if (any || record.name() == type) {
                 updateNames.insert(record.target());
+                cacheRecord = true;
             }
             break;
         case SRV:
         case TXT:
             if (any || record.name().endsWith("." + type)) {
                 updateNames.insert(record.name());
+                cacheRecord = true;
             }
             break;
+        }
+        if (cacheRecord) {
+            cache->addRecord(record);
         }
     }
 
@@ -148,6 +157,21 @@ void BrowserPrivate::onMessageReceived(const Message &message)
     for (const QByteArray &name : qAsConst(updateNames)) {
         if (updateService(name)) {
             queryNames.insert(name);
+        }
+    }
+
+    // Cache A / AAAA records after services are processed to ensure hostnames are known
+    for (const Record &record : records) {
+        bool cacheRecord = false;
+
+        switch (record.type()) {
+            case A:
+            case AAAA:
+                cacheRecord = hostnames.contains(record.name());
+                break;
+        }
+        if (cacheRecord) {
+            cache->addRecord(record);
         }
     }
 
@@ -202,6 +226,7 @@ void BrowserPrivate::onRecordExpired(const Record &record)
     if (!service.name().isNull()) {
         emit q->serviceRemoved(service);
         services.remove(serviceName);
+        updateHostnames();
     }
 }
 
@@ -250,6 +275,15 @@ void BrowserPrivate::onServiceTimeout()
 
         server->sendMessageToAll(message);
         ptrTargets.clear();
+    }
+}
+
+void BrowserPrivate::updateHostnames()
+{
+    hostnames.clear();
+
+    for (const auto& service : services) {
+        hostnames.insert(service.hostname());
     }
 }
 

--- a/src/src/browser_p.h
+++ b/src/src/browser_p.h
@@ -58,6 +58,7 @@ public:
     Cache *cache;
     QSet<QByteArray> ptrTargets;
     QMap<QByteArray, Service> services;
+    QSet<QByteArray> hostnames;
 
     QTimer queryTimer;
     QTimer serviceTimer;
@@ -72,6 +73,7 @@ private Q_SLOTS:
     void onServiceTimeout();
 
 private:
+    void updateHostnames();
 
     Browser *const q;
 };


### PR DESCRIPTION
Addresses the following issue: https://github.com/nitroshare/qmdnsengine/issues/20

Only cache SRV, TXT and PTR records when they are intended for the browser type or cache all of them if the browser type is any.
Only cache A / AAAA records when the hostname is a known service. Services are processed before to ensure that A / AAAA records are still caches when they appear before the SRV record in the same message.

QMdnsEngine doesn't use other records types so these aren't cached currently to avoid unneeded traffic on the network.