### PR TITLE
src: probe: Fix usage of QStringBuilder

### DIFF
--- a/src/src/prober.cpp
+++ b/src/src/prober.cpp
@@ -56,8 +56,11 @@ ProberPrivate::ProberPrivate(Prober *prober, AbstractServer *server, const Recor
 void ProberPrivate::assertRecord()
 {
     // Use the current suffix to set the name of the proposed record
-    proposedRecord.setName(suffix == 1 ?
-        name + type : name + "-" + QByteArray::number(suffix) + type);
+    QString name = suffix == 1
+        ? QStringLiteral("%1%2").arg(name, type)
+        : QStringLiteral("%1-%2%3").arg(name, QByteArray::number(suffix), type);
+
+    proposedRecord.setName(name.toLatin1());
 
     // Broadcast a query for the proposed name (using an ANY query) and
     // include the proposed record in the query


### PR DESCRIPTION
It fixes a problem when building with QStringBuilder:
```
error: operands to ‘?:’ have different types ‘QStringBuilder<QByteArray, QByteArray>’ and ‘QStringBuilder<QStringBuilder<QStringBuilder<QByteArray, char [2]>, QByteArray>, QByteArray>’                                                                                                     
```