### PR TITLE
Support Qt5 and Qt6 builds in parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,26 @@ set(INCLUDE_INSTALL_DIR include CACHE STRING "Header installation directory rela
 set(DOC_INSTALL_DIR share/doc/qmdnsengine CACHE STRING "Documentation installation directory relative to the install prefix")
 set(EXAMPLES_INSTALL_DIR "${LIB_INSTALL_DIR}/qmdnsengine/examples" CACHE STRING "Examples installation directory relative to the install prefix")
 
-find_package(Qt5Network 5.7 REQUIRED)
+if (CMAKE_PREFIX_PATH)
+	message( STATUS "QMdnsEngine: Use CMAKE_PREFIX_PATH to locate Qt version to be used: ${CMAKE_PREFIX_PATH}" )
+endif()
+
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Network Widgets REQUIRED)
+message( STATUS "QMdnsEngine: Found Qt Version: ${QT_VERSION}" )
+
+if (${QT_VERSION_MAJOR} GREATER_EQUAL 6 )
+	SET(QT_MIN_VERSION "6.0.0")
+else()
+	SET(QT_MIN_VERSION "5.7.0")
+endif()
+
+if ( "${QT_VERSION}" VERSION_LESS "${QT_MIN_VERSION}" )
+	message( FATAL_ERROR "Your Qt version is to old! Minimum required ${QT_MIN_VERSION}" )
+endif()
+
+find_package(Qt${QT_VERSION_MAJOR} ${QT_VERSION} COMPONENTS Network Widgets REQUIRED)
+
+message( STATUS "QMdnsEngine: Qt version used: ${QT_VERSION}" )
 
 set(CMAKE_AUTOMOC ON)
 
@@ -42,13 +61,13 @@ endif()
 
 option(BUILD_EXAMPLES "Build example applications" OFF)
 if(BUILD_EXAMPLES)
-    find_package(Qt5Widgets 5.7)
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
     add_subdirectory(examples)
 endif()
 
 option(BUILD_TESTS "Build test suite" OFF)
 if(BUILD_TESTS)
-    find_package(Qt5Test 5.7 REQUIRED)
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if (CMAKE_PREFIX_PATH)
 	message( STATUS "QMdnsEngine: Use CMAKE_PREFIX_PATH to locate Qt version to be used: ${CMAKE_PREFIX_PATH}" )
 endif()
 
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Network Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Network REQUIRED)
 message( STATUS "QMdnsEngine: Found Qt Version: ${QT_VERSION}" )
 
 if (${QT_VERSION_MAJOR} GREATER_EQUAL 6 )
@@ -38,7 +38,7 @@ if ( "${QT_VERSION}" VERSION_LESS "${QT_MIN_VERSION}" )
 	message( FATAL_ERROR "Your Qt version is to old! Minimum required ${QT_MIN_VERSION}" )
 endif()
 
-find_package(Qt${QT_VERSION_MAJOR} ${QT_VERSION} COMPONENTS Network Widgets REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} ${QT_VERSION} COMPONENTS Network REQUIRED)
 
 message( STATUS "QMdnsEngine: Qt version used: ${QT_VERSION}" )
 

--- a/examples/browser/CMakeLists.txt
+++ b/examples/browser/CMakeLists.txt
@@ -10,7 +10,7 @@ set_target_properties(browser PROPERTIES
     CXX_STANDARD 11
 )
 
-target_link_libraries(browser qmdnsengine Qt5::Widgets)
+target_link_libraries(browser qmdnsengine Qt${QT_VERSION_MAJOR}::Widgets)
 
 install(TARGETS browser
     RUNTIME DESTINATION "${EXAMPLE_DIR}"

--- a/examples/provider/CMakeLists.txt
+++ b/examples/provider/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SRC
 
 add_executable(provider WIN32 ${SRC})
 
-target_link_libraries(provider qmdnsengine Qt5::Widgets)
+target_link_libraries(provider qmdnsengine Qt${QT_VERSION_MAJOR}::Widgets)
 
 install(TARGETS provider
     RUNTIME DESTINATION "${EXAMPLE_DIR}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,7 +61,7 @@ target_include_directories(qmdnsengine PUBLIC
     "$<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>"
 )
 
-target_link_libraries(qmdnsengine Qt5::Network)
+target_link_libraries(qmdnsengine Qt${QT_VERSION_MAJOR}::Network)
 
 install(TARGETS qmdnsengine
     EXPORT        qmdnsengine-export

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach(_test ${TESTS})
         CXX_STANDARD_REQUIRED ON
     )
     target_include_directories(${_test} PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
-    target_link_libraries(${_test} qmdnsengine Qt5::Test common)
+    target_link_libraries(${_test} qmdnsengine Qt${QT_VERSION_MAJOR}::Test common)
     add_test(NAME ${_test}
         COMMAND ${_test}
     )

--- a/tests/TestDns.cpp
+++ b/tests/TestDns.cpp
@@ -230,7 +230,6 @@ void TestDns::testWriteName()
 {
     QFETCH(QByteArray, initialPacket);
     QFETCH(quint16, initialOffset);
-    QFETCH(quint16, correctOffset);
     QFETCH(QByteArray, name);
     QFETCH(NameMap, nameMap);
     QFETCH(QByteArray, correctPacket);


### PR DESCRIPTION
The PR is to allow building the qmdnsengine code in a Qt5, as well as Qt6 context.

The Qt version is identified automatically or the Qt installation to be used can be passed via the `CMAKE_PREFIX_PATH`.
That allows projects to easily pass the used Qt version to the qmdnsengine submodule build.

e.g.
`CMAKE_PREFIX_PATH="/opt/Qt/6.2.0/gcc_64" cmake -f CMakeLists.txt `