### PR TITLE
Fix Compile error introduced by PR34

### DIFF
--- a/src/src/prober.cpp
+++ b/src/src/prober.cpp
@@ -55,12 +55,12 @@ ProberPrivate::ProberPrivate(Prober *prober, AbstractServer *server, const Recor
 
 void ProberPrivate::assertRecord()
 {
-    // Use the current suffix to set the name of the proposed record
-    QString name = suffix == 1
-        ? QStringLiteral("%1%2").arg(name, type)
-        : QStringLiteral("%1-%2%3").arg(name, QByteArray::number(suffix), type);
+	// Use the current suffix to set the name of the proposed record
+	QString tmpName = suffix == 1
+						  ? QString("%1%2").arg(name, type.constData())
+						  : QString("%1-%2%3").arg(name.constData(), QByteArray::number(suffix), type);
 
-    proposedRecord.setName(name.toLatin1());
+	proposedRecord.setName(tmpName.toUtf8());
 
     // Broadcast a query for the proposed name (using an ANY query) and
     // include the proposed record in the query


### PR DESCRIPTION
PR34 results in a compile error of overloaded ambiguity. This has been fixed.
In addition clang findings were addressed and clear differentiation between member and temp variables done.

Building latest master under Ubuntu 20.04 with Qt 5.12.8 (and Qt 6.2.0) results in:

```
Building CXX object src/CMakeFiles/qmdnsengine.dir/src/prober.cpp.o
/home/thomas/qmdnsengine/src/src/prober.cpp: In member function ‘void QMdnsEngine::ProberPrivate::assertRecord()’:
/home/thomas/qmdnsengine/src/src/prober.cpp:59:48: error: call of overloaded ‘arg(QString&, QByteArray&)’ is ambiguous
   59 |         ? QStringLiteral("%1%2").arg(name, type)
      |                                                ^
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qobject.h:47,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/QObject:1,
                 from /home/thomas/qmdnsengine/src/include/qmdnsengine/abstractserver.h:28,
                 from /home/thomas/qmdnsengine/src/src/prober.cpp:25:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:298:31: note: candidate: ‘QString QString::arg(const QString&, int, QChar) const’
  298 |     Q_REQUIRED_RESULT QString arg(const QString &a, int fieldWidth = 0,
      |                               ^~~
/usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:301:31: note: candidate: ‘QString QString::arg(QStringView, int, QChar) const’
  301 |     Q_REQUIRED_RESULT QString arg(QStringView a, int fieldWidth = 0,
      |                               ^~~
/usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:987:16: note: candidate: ‘QString QString::arg(const QString&, const QString&) const’
  987 | inline QString QString::arg(const QString &a1, const QString &a2) const
      |                ^~~~~~~
make[2]: *** [src/CMakeFiles/qmdnsengine.dir/build.make:180: src/CMakeFiles/qmdnsengine.dir/src/prober.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:156: src/CMakeFiles/qmdnsengine.dir/all] Error 2

```



