### PR TITLE
Support Qt 6.7.0 - Address that qAsConst has been deprecated

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,8 +44,18 @@ endif()
 
 add_library(qmdnsengine ${HEADERS} ${SRC})
 
+if ( "${QT_VERSION}" VERSION_GREATER_EQUAL "6.7.0" )
+    message( STATUS "QMdnsEngine: Enable C++17 for Qt 6.7 and newer" )
+    set_target_properties(qmdnsengine PROPERTIES
+        CXX_STANDARD          17
+    )
+else()
+	set_target_properties(qmdnsengine PROPERTIES
+        CXX_STANDARD          11
+    )
+endif()
+
 set_target_properties(qmdnsengine PROPERTIES
-    CXX_STANDARD          17
     CXX_STANDARD_REQUIRED ON
     DEFINE_SYMBOL         QT_NO_SIGNALS_SLOTS_KEYWORDS
     DEFINE_SYMBOL         QT_NO_FOREACH

--- a/src/src/browser.cpp
+++ b/src/src/browser.cpp
@@ -91,7 +91,11 @@ bool BrowserPrivate::updateService(const QByteArray &fqName)
     QList<Record> txtRecords;
     if (cache->lookupRecords(fqName, TXT, txtRecords)) {
         QMap<QByteArray, QByteArray> attributes;
-        for (const Record &record : std::as_const(txtRecords)) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+		for (const Record &record : std::as_const(txtRecords)) {
+#else
+		for (const Record &record : qAsConst(txtRecords)) {
+#endif
             for (auto i = record.attributes().constBegin();
                     i != record.attributes().constEnd(); ++i) {
                 attributes.insert(i.key(), i.value());
@@ -156,7 +160,11 @@ void BrowserPrivate::onMessageReceived(const Message &message)
     // For each of the services marked to be updated, perform the update and
     // make a list of all missing SRV records
     QSet<QByteArray> queryNames;
-    for (const QByteArray &name : std::as_const(updateNames)) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+	for (const QByteArray &name : std::as_const(updateNames)) {
+#else
+	for (const QByteArray &name : qAsConst(updateNames)) {
+#endif
         if (updateService(name)) {
             queryNames.insert(name);
         }
@@ -180,7 +188,11 @@ void BrowserPrivate::onMessageReceived(const Message &message)
     // Build and send a query for all of the SRV and TXT records
     if (queryNames.count()) {
         Message queryMessage;
-        for (const QByteArray &name : std::as_const(queryNames)) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+		for (const QByteArray &name : std::as_const(queryNames)) {
+#else
+		for (const QByteArray &name : qAsConst(queryNames)) {
+#endif
             Query query;
             query.setName(name);
             query.setType(SRV);
@@ -242,7 +254,11 @@ void BrowserPrivate::onQueryTimeout()
     // Include PTR records for the target that are already known
     QList<Record> records;
     if (cache->lookupRecords(query.name(), PTR, records)) {
-        for (const Record &record : std::as_const(records)) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+		for (const Record &record : std::as_const(records)) {
+#else
+		for (const Record &record : qAsConst(records)) {
+#endif
             message.addRecord(record);
         }
     }
@@ -255,8 +271,11 @@ void BrowserPrivate::onServiceTimeout()
 {
     if (ptrTargets.count()) {
         Message message;
-        for (const QByteArray &target : std::as_const(ptrTargets)) {
-
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+		for (const QByteArray &target : std::as_const(ptrTargets)) {
+#else
+		for (const QByteArray &target : qAsConst(ptrTargets)) {
+#endif
             // Add a query for PTR records
             Query query;
             query.setName(target);
@@ -266,7 +285,11 @@ void BrowserPrivate::onServiceTimeout()
             // Include PTR records for the target that are already known
             QList<Record> records;
             if (cache->lookupRecords(target, PTR, records)) {
-                for (const Record &record : std::as_const(records)) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 7, 0))
+				for (const Record &record : std::as_const(records)) {
+#else
+				for (const Record &record : qAsConst(records)) {
+#endif
                     message.addRecord(record);
                 }
             }


### PR DESCRIPTION
With Qt 6.7.0 qAsConst is marked as deprecated.

Refactoring was done to use "std::as_const" as the recommended alternative way.
"std::as_const" require C++17 standard.