### PR TITLE
QT6.9 - Fix missing QDebug include

### DIFF
--- a/src/include/qmdnsengine/service.h
+++ b/src/include/qmdnsengine/service.h
@@ -29,6 +29,7 @@
 #include <QHostAddress>
 #include <QList>
 #include <QMap>
+#include <QDebug>
 
 #include "qmdnsengine_export.h"
 


### PR DESCRIPTION
The current code does not compile, as a QDebug include is missing.

The PR addresses the issue to have qmdnsengine compile sucessfully with Qt6.9

```
/home/thomas/hyperion.ng-lordgrey-test/dependencies/external/qmdnsengine/src/src/service.cpp:125:39: error: ‘debug’ has incomplete type
  125 | QDebug QMdnsEngine::operator<<(QDebug debug, const Service &service)
      |                                ~~~~~~~^~~~~
In file included from /home/thomas/Qt/6.9.0/gcc_64/include/QtCore/qglobal.h:45,
                 from /home/thomas/Qt/6.9.0/gcc_64/include/QtCore/qnamespace.h:12,
                 from /home/thomas/Qt/6.9.0/gcc_64/include/QtCore/qbytearray.h:9,
                 from /home/thomas/Qt/6.9.0/gcc_64/include/QtCore/QByteArray:1,
                 from /home/thomas/hyperion.ng-lordgrey-test/dependencies/external/qmdnsengine/src/include/qmdnsengine/service.h:28,
                 from /home/thomas/hyperion.ng-lordgrey-test/dependencies/external/qmdnsengine/src/src/service.cpp:25:
/home/thomas/Qt/6.9.0/gcc_64/include/QtCore/qtypeinfo.h:15:7: note: forward declaration of ‘class QDebug’
   15 | class QDebug;
      |       ^~~~~~
/home/thomas/hyperion.ng-lordgrey-test/dependencies/external/qmdnsengine/src/src/service.cpp:125:68: error: return type ‘class QDebug’ is incomplete
  125 | QDebug QMdnsEngine::operator<<(QDebug debug, const Service &service)
      |                                                                    ^
/home/thomas/hyperion.ng-lordgrey-test/dependencies/external/qmdnsengine/src/src/service.cpp:125:8: error: ambiguating new declaration of ‘void QMdnsEngine::operator<<(QDebug, const Service&)’
  125 | QDebug QMdnsEngine::operator<<(QDebug debug, const Service &service)
      |        ^~~~~~~~~~~
/home/thomas/hyperion.ng-lordgrey-test/dependencies/external/qmdnsengine/src/include/qmdnsengine/service.h:152:27: note: old declaration ‘QDebug QMdnsEngine::operator<<(QDebug, const Service&)’
  152 | QMDNSENGINE_EXPORT QDebug operator<<(QDebug debug, const Service &service);
      |                           ^~~~~~~~
/home/thomas/hyperion.ng-lordgrey-test/dependencies/external/qmdnsengine/src/src/service.cpp: In function ‘void QMdnsEngine::operator<<(QDebug, const Service&)’:
/home/thomas/hyperion.ng-lordgrey-test/dependencies/external/qmdnsengine/src/src/service.cpp:127:5: error: ‘QDebugStateSaver’ was not declared in this scope
  127 |     QDebugStateSaver saver(debug);
      |     ^~~~~~~~~~~~~~~~
In file included from /home/thomas/Qt/6.9.0/gcc_64/include/QtCore/qglobal.h:26:
/home/thomas/hyperion.ng-lordgrey-test/dependencies/external/qmdnsengine/src/src/service.cpp:128:14: error: ‘saver’ was not declared in this scope
  128 |     Q_UNUSED(saver);
```



