### PR TITLE
compatibility with CMake ≥ 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2.0)
+cmake_minimum_required(VERSION 3.5)
 project(qmdnsengine)
 
 set(PROJECT_NAME "QMdnsEngine")


### PR DESCRIPTION
@nathan-osman Sorry, I just came across another issue....

Builds with newer cmake versions greater than 4 fail as Compatibility with CMake < 3.5  was removed.
The PR increases the minimum version.

"Changed in version 4.0: Compatibility with versions of CMake older than 3.5 is removed. Calls to cmake_minimum_required(VERSION) or cmake_policy(VERSION) that do not specify at least 3.5 as their policy version (optionally via ...<max>) will produce an error in CMake 4.0 and above."



```
 CMake Error at hyperion/dependencies/external/qmdnsengine/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
```