### PR TITLE
Fix use after free in assignment operator

### DIFF
--- a/src/src/bitmap.cpp
+++ b/src/src/bitmap.cpp
@@ -68,8 +68,10 @@ Bitmap::Bitmap(const Bitmap &other)
 
 Bitmap &Bitmap::operator=(const Bitmap &other)
 {
-    d->free();
-    d->fromData(other.d->length, other.d->data);
+    if (this != &other) {
+        d->free();
+        d->fromData(other.d->length, other.d->data);
+    }
     return *this;
 }
 


### PR DESCRIPTION
Classic use-after-free in Bitmap::operator=(). Not sure if it is ever invoked in practice but easily found with clang's static analyzer. Feel free to merge if you feel it's worth it.